### PR TITLE
Fixing Tabtip not opening in Win10 and updating to NetCore+

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,10 @@ More value available in [.Net documentation](https://docs.microsoft.com/fr-fr/do
 
 ## Test
 You can test the behaviors with the included test application. Set UITest project as 'Set as startup projet' and run. 
+
+## Framework Support
+
+.Net Framework 4.72
+.Net Framework 4.8
+.Net Core 3.1
+.Net 5.0-windows

--- a/UITest/UITest.csproj
+++ b/UITest/UITest.csproj
@@ -1,143 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{A0E4A0A6-118A-4ED8-9AEE-B127B565EE02}</ProjectGuid>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <OutputType>WinExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>UITest</RootNamespace>
-    <AssemblyName>UITest</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <WarningLevel>4</WarningLevel>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <UseWPF>true</UseWPF>
+    <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Management" />
-    <Reference Include="System.Reactive.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.Core.3.0.0\lib\net45\System.Reactive.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Reactive.Interfaces, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.Interfaces.3.0.0\lib\net45\System.Reactive.Interfaces.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Reactive.Linq, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.Linq.3.0.0\lib\net45\System.Reactive.Linq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Reactive.PlatformServices, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.PlatformServices.3.0.0\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Reactive.Windows.Threading, Version=3.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Reactive.Windows.Threading.3.0.0\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xaml">
-      <RequiredTargetFramework>4.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="WindowsBase" />
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
-  </ItemGroup>
-  <ItemGroup>
-    <ApplicationDefinition Include="App.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </ApplicationDefinition>
-    <Page Include="DialogWindow.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="MainWindow.xaml">
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
-    </Page>
-    <Compile Include="App.xaml.cs">
-      <DependentUpon>App.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="DialogWindow.xaml.cs">
-      <DependentUpon>DialogWindow.xaml</DependentUpon>
-    </Compile>
-    <Compile Include="MainWindow.xaml.cs">
-      <DependentUpon>MainWindow.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Properties\Resources.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>Resources.resx</DependentUpon>
-    </Compile>
-    <Compile Include="Properties\Settings.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Settings.settings</DependentUpon>
-      <DesignTimeSharedInput>True</DesignTimeSharedInput>
-    </Compile>
-    <EmbeddedResource Include="Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <None Include="packages.config" />
-    <None Include="Properties\Settings.settings">
-      <Generator>SettingsSingleFileGenerator</Generator>
-      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-    </None>
     <AppDesigner Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <ProjectReference Include="..\WPFTabTip\WPFTabTipMixedHardware.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\WPFTabTip\WPFTabTipMixedHardware.csproj">
-      <Project>{be335058-c5de-4eb6-8eeb-8e6fc9f5081b}</Project>
-      <Name>WPFTabTipMixedHardware</Name>
-    </ProjectReference>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/WPFTabTip.sln
+++ b/WPFTabTip.sln
@@ -5,13 +5,13 @@ VisualStudioVersion = 16.0.29503.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WPFTabTipMixedHardware", "WPFTabTip\WPFTabTipMixedHardware.csproj", "{BE335058-C5DE-4EB6-8EEB-8E6FC9F5081B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UITest", "UITest\UITest.csproj", "{A0E4A0A6-118A-4ED8-9AEE-B127B565EE02}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A289E40F-306F-4D4A-8F41-0D95C6FBCE45}"
 	ProjectSection(SolutionItems) = preProject
 		LICENSE.md = LICENSE.md
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UITest", "UITest\UITest.csproj", "{C6AB583C-5BEB-47E8-A979-B00E54027C08}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,10 +23,10 @@ Global
 		{BE335058-C5DE-4EB6-8EEB-8E6FC9F5081B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BE335058-C5DE-4EB6-8EEB-8E6FC9F5081B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BE335058-C5DE-4EB6-8EEB-8E6FC9F5081B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A0E4A0A6-118A-4ED8-9AEE-B127B565EE02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A0E4A0A6-118A-4ED8-9AEE-B127B565EE02}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A0E4A0A6-118A-4ED8-9AEE-B127B565EE02}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A0E4A0A6-118A-4ED8-9AEE-B127B565EE02}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C6AB583C-5BEB-47E8-A979-B00E54027C08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C6AB583C-5BEB-47E8-A979-B00E54027C08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C6AB583C-5BEB-47E8-A979-B00E54027C08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C6AB583C-5BEB-47E8-A979-B00E54027C08}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WPFTabTip/Helpers/TabTip.cs
+++ b/WPFTabTip/Helpers/TabTip.cs
@@ -39,7 +39,7 @@ namespace WPFTabTipMixedHardware.Helpers
         private static extern UInt32 GetWindowLong(IntPtr hWnd, int nIndex);
 
         /// <summary>
-        /// Signals that TabTip was closed after it was opened 
+        /// Signals that TabTip was closed after it was opened
         /// with a call to StartPoolingForTabTipClosedEvent method
         /// </summary>
         internal static event Action Closed;
@@ -65,7 +65,7 @@ namespace WPFTabTipMixedHardware.Helpers
 
             try
             {
-                Process.Start(TabTipExecPath);
+                Process.Start(new ProcessStartInfo(TabTipExecPath){ UseShellExecute = true });
             }
             catch (Exception ex)
             {

--- a/WPFTabTip/TabTipAutomation.cs
+++ b/WPFTabTip/TabTipAutomation.cs
@@ -160,9 +160,7 @@ namespace WPFTabTipMixedHardware
                 .Do(_ => TabTip.Close())
                 .Subscribe(_ => tabTipClosedSubject.OnNext(true));
 
-            tabTipClosedSubject
-                .ObserveOnDispatcher()
-                .Subscribe(_ => AnimationHelper.GetEverythingInToWorkAreaWithTabTipClosed());
+            tabTipClosedSubject.Subscribe(_ => AnimationHelper.GetEverythingInToWorkAreaWithTabTipClosed());
         }
 
         private static bool AnotherAuthorizedElementFocused()
@@ -198,8 +196,7 @@ namespace WPFTabTipMixedHardware
                 .ObserveOn(Scheduler.Default)
                 .Where(_ => IgnoreHardwareKeyboard == HardwareKeyboardIgnoreOptions.IgnoreAll || !HardwareKeyboard.IsConnectedAsync().Result)
                 .Where(tuple => tuple.Item2 == true)
-                .Do(_ => TabTip.OpenUndockedAndStartPoolingForClosedEvent())
-                .ObserveOnDispatcher()
+                .Do(_ => TabTip.OpenUndockedAndStartPoolingForClosedEvent())    
                 .Subscribe(tuple => AnimationHelper.GetUIElementInToWorkAreaWithTabTipOpened(tuple.Item1));
         }
 

--- a/WPFTabTip/WPFTabTipMixedHardware.csproj
+++ b/WPFTabTip/WPFTabTipMixedHardware.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net47</TargetFrameworks>
+    <TargetFrameworks>net472;net48;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <Title>WPFTabTipMixedHardware</Title>
-    <Version>1.3.5</Version>
+    <Version>1.3.6</Version>
     <Copyright></Copyright>
     <Description>Simple TabTip / Virtual Keyboard integration for WPF apps with mixed Keyboard and Touchscreen</Description>
     <Authors>Morgan SOULLEZ</Authors>
@@ -10,29 +10,27 @@
     <PackageProjectUrl>https://github.com/seuleuzeuh/WPFTabTipMixedhardware/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/seuleuzeuh/WPFTabTipMixedhardware/</RepositoryUrl>
     <PackageTags>WPF Touchscreen TabTip Keyboard Virtual W10</PackageTags>
-    <PackageReleaseNotes>- Process and Registry access securing</PackageReleaseNotes>
-    <AssemblyVersion>1.3.5</AssemblyVersion>
-    <FileVersion>1.3.5</FileVersion>
+    <PackageReleaseNotes>- Fixing Tabtip not opening in Win10
+- Updating the project to target .NetFramework, .NetCore and .Net5</PackageReleaseNotes>
+    <AssemblyVersion>1.3.6</AssemblyVersion>
+    <FileVersion>1.3.6</FileVersion>
+    <UseWPF>true</UseWPF>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.Reactive.Core" Version="4.4.1" />
-    <PackageReference Include="System.Reactive.Interfaces" Version="4.4.1" />
-    <PackageReference Include="System.Reactive.Linq" Version="4.4.1" />
-    <PackageReference Include="System.Reactive.PlatformServices" Version="4.4.1" />
-    <PackageReference Include="System.Reactive.Windows.Threading" Version="4.4.1" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Reactive.Compatibility" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="PresentationCore" />
-    <Reference Include="PresentationFramework" />
     <Reference Include="System.Management" />
-    <Reference Include="System.Windows" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\LICENSE.md">
       <Pack>True</Pack>
-      <PackagePath></PackagePath>
+      <PackagePath>
+      </PackagePath>
     </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Process info was missing to enable shell execution when starting tabtip.exe.

I also updatied the project to target .NetFramework (4.72,48), .NetCore 3.1 and .Net5.0-windows